### PR TITLE
Fix service manger's alias for DocumentManager.

### DIFF
--- a/src/DoctrineMongoODMModule/Module.php
+++ b/src/DoctrineMongoODMModule/Module.php
@@ -143,7 +143,7 @@ class Module implements
                 'DoctrineMongoODMModule\Logging\EchoLogger'  => 'DoctrineMongoODMModule\Logging\EchoLogger',
             ),
             'aliases' => array(
-                'Doctrine\ODM\Mongo\DocumentManager' => 'doctrine.documentmanager.odm_default',
+                'Doctrine\ODM\MongoDB\DocumentManager' => 'doctrine.documentmanager.odm_default',
             ),
             'factories' => array(
                 'doctrine.authenticationadapter.odm_default'  => new CommonService\Authentication\AdapterFactory('odm_default'),


### PR DESCRIPTION
I noticed that the alias setup in the Module.php is not matching the current DocumentManager fully qualified class name.
